### PR TITLE
seti: update base01.

### DIFF
--- a/seti.yaml
+++ b/seti.yaml
@@ -2,7 +2,7 @@
 scheme: "Seti UI"
 author: ""
 base00: "151718"
-base01: "8ec43d"
+base01: "282a2b"
 base02: "3B758C"
 base03: "41535B"
 base04: "43a5d5"


### PR DESCRIPTION
As discussed in chriskempson/base16-vim#110, vim is unusable with
the current color IMHO, and others seem to agree.